### PR TITLE
Clean up image view for backoffice

### DIFF
--- a/UmbracoBlockGrid/App_Plugins/UmbracoBlockGrid/BlockViews/imageBlock.html
+++ b/UmbracoBlockGrid/App_Plugins/UmbracoBlockGrid/BlockViews/imageBlock.html
@@ -3,33 +3,9 @@
     :host {
         min-height: 160px;
     }
-    
-    button > * {
-        vertical-align: middle;
-    }
-    button {
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
+
+    .image-container {
         cursor: pointer;
-        color: black;
-        background-color: transparent;
-        text-align: left;
-        padding: 0;
-        user-select: none;
-        border: none;
-        transition: border-color 120ms, background-color 120ms;
-        max-height: 80vh;
-        overflow:hidden;
-    }
-    button:hover {
-        color: #2152A3;
-    }
-    img {
-        flex-grow: 0;
     }
 
     .icon {
@@ -66,9 +42,9 @@
 </style>
 
 
-<button type="button" ng-click="block.edit()" ng-focus="block.focus">
+<div class="image-container" ng-click="block.edit()" ng-focus="block.focus">
     {{mediaItem = (block.data.image[0].mediaKey | mediaItemResolver); ""}}
     <img class="image" draggable="false" ng-if="mediaItem !== null && (mediaItem.mediaLink.indexOf('svg') === -1)" ng-src="{{mediaItem.mediaLink}}?width=1920" alt="{{mediaItem.name}}" />
     <umb-icon ng-if="mediaItem !== null && (mediaItem.mediaLink.indexOf('svg') !== -1)" icon="{{mediaItem.contentType.icon}} color-black" class="icon"></umb-icon>
     <span ng-if="mediaItem !== null && mediaItem.name" class="file-name">{{mediaItem.name}}</span>
-</button>
+</div>


### PR DESCRIPTION
Make the backoffice view use a div tag as clickable container (like the rest of the backoffice views) instead of a button tag.