### PR TITLE
Calculate text columns from CSS variable instead of using Razor

### DIFF
--- a/UmbracoBlockGrid.Site/Views/Partials/blockgrid/Components/richTextBlock.cshtml
+++ b/UmbracoBlockGrid.Site/Views/Partials/blockgrid/Components/richTextBlock.cshtml
@@ -1,4 +1,4 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockGridItem<RichTextBlock>>
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
 
-<div class="rich-text @(Model.ColumnSpan == 12 ? "--two-columns" : null)">@Model.Content.RichText</div>
+<div class="rich-text">@Model.Content.RichText</div>

--- a/UmbracoBlockGrid.Site/wwwroot/css/myblockgridlayout.css
+++ b/UmbracoBlockGrid.Site/wwwroot/css/myblockgridlayout.css
@@ -120,17 +120,15 @@ h2 {
 .rich-text {
     font-weight: 300;
     text-align: var(--my-text-align, left);
-    color: var(--my-text-color, inherit);   
+    color: var(--my-text-color, inherit);
+    columns: max(1, calc(var(--umb-block-grid--item-column-span) - 10));
+    column-gap: 60px;
 }
 
 .rich-text > p:first-child {
     margin-top:0;
 }
 
-.rich-text.--two-columns {
-    columns: 2;
-    column-gap: 60px;
-}
 
 
 


### PR DESCRIPTION
Calculate columns for text (richText block) using the `--umb-block-grid--item-column-span` CSS variable instead of using Razor. This also makes the text columns reflect in the backoffice 😄 

![image](https://user-images.githubusercontent.com/7405322/204519907-00ac236e-3b1e-4718-ae50-f9db8c14ce8f.png)
